### PR TITLE
Hello world.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,59 @@
+> [!NOTE]
+> This extension aims to have similar functionality as described in this no longer maintained GH CLI [Extension](https://docs.github.com/en/codespaces/developing-in-a-codespace/connecting-to-a-private-network#using-the-github-cli-extension-to-access-remote-resources):
+>
+> `.. allows you to create a bridge between a codespace and your local machine, so that the codespace can access any remote resource that is accessible from your machine. The codespace uses your local machine as a network gateway to reach those resources.`
+
 # cs-vpn
-Codespace VPN
+### Codespace VPN
+
+
+Route select internet traffic through GitHub Codespaces using `sshuttle`, and optionally set up SSH reverse tunnels so the Codespace can access services on your local machine.
+
+## Installation
+
+```bash
+gh extension install appatalks/cs-vpn
+```
+
+## Usage
+
+```bash
+gh codespaces proxy <codespace-name> [flags]
+```
+
+## Flags
+
+`--all`             Route all traffic (0.0.0.0/0) through the Codespace
+
+`--only-443`        Route only HTTPS/TLS traffic (0.0.0.0/0:443)
+
+`--dns`             Include DNS queries in the tunnel
+
+`--domains "..."`  Route HTTPS traffic for specific domains (space-separated list)
+
+`--gateway`         Set up a reverse SSH tunnel so the Codespace can reach your localhost (default local:8000 → remote:9000)
+
+`-h`, `--help`      Show usage
+
+## Examples
+
+1. Route only TLS + DNS:
+  ```bash
+  gh codespaces proxy my-codespace --only-443 --dns
+  ```
+
+2. Route GitHub domains + set up local gateway:
+  ```bash
+  gh codespaces proxy my-codespace --domains "github.com api.github.com" --gateway
+  ```
+
+3. Route all traffic:
+  ```bash
+  gh codespaces proxy my-codespace --all
+  ```
+
+4. Custom local port mapping (use env vars before running):
+  ```bash
+  export LOCAL_PORT=3000 REMOTE_PORT=9001
+  gh codespaces proxy my-codespace --gateway
+  ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
+> [!CAUTION]
+> Not ready for production use.
+
 > [!NOTE]
 > This extension aims to have similar functionality as described in this no longer maintained GH CLI [Extension](https://docs.github.com/en/codespaces/developing-in-a-codespace/connecting-to-a-private-network#using-the-github-cli-extension-to-access-remote-resources):
 >
 > `.. allows you to create a bridge between a codespace and your local machine, so that the codespace can access any remote resource that is accessible from your machine. The codespace uses your local machine as a network gateway to reach those resources.`
 
 # cs-vpn
-### Codespace VPN
+### GitHub Cli Extension: Gateway-Proxy/VPN for Codespaces
+<br>
 
 
 Route select internet traffic through GitHub Codespaces using `sshuttle`, and optionally set up SSH reverse tunnels so the Codespace can access services on your local machine.

--- a/cs-vpn
+++ b/cs-vpn
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -e
+
+print_usage() {
+  echo "Usage: gh codespaces proxy <codespace-name> [--all] [--dns] [--only-443] [--domains \"domain1 domain2\"] [--gateway]"
+}
+
+# Ensure subcommand
+if [[ "${1}" != "proxy" ]]; then
+  print_usage
+  exit 1
+fi
+shift
+
+# Codespace name
+if [[ -z "$1" ]]; then
+  print_usage
+  exit 1
+fi
+CODESPACE="$1"
+shift
+
+# Defaults
+ROUTES=()
+USE_DNS=false
+BRIDGE=false
+
+# Parse flags
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --all)
+      ROUTES+=("0.0.0.0/0");;
+    --only-443)
+      ROUTES+=("0.0.0.0/0:443");;
+    --dns)
+      USE_DNS=true;;
+    --domains)
+      shift
+      for domain in $1; do
+        ROUTES+=("${domain}:443")
+      done
+      ;;
+    --gateway)
+      BRIDGE=true;;
+    -h|--help)
+      print_usage
+      exit 0;;
+    *)
+      echo "Unknown option: $1"
+      print_usage
+      exit 1;;
+  esac
+  shift
+done
+
+# Ensure SSH config for Codespace
+if ! grep -q "$CODESPACE" ~/.ssh/config 2>/dev/null; then
+  gh codespace ssh --codespace "$CODESPACE" --config >> ~/.ssh/config
+fi
+
+# Start sshuttle if routes defined
+if [[ ${#ROUTES[@]} -gt 0 ]]; then
+  CMD=(sshuttle -r "$CODESPACE")
+  [[ "$USE_DNS" == true ]] && CMD+=(--dns)
+  for r in "${ROUTES[@]}"; do CMD+=("$r"); done
+  echo "Starting sshuttle: ${CMD[*]}"
+  "${CMD[@]}" &
+  SSHUTTLE_PID=$!
+fi
+
+# Setup reverse SSH tunnel if requested
+if [[ "$BRIDGE" == true ]]; then
+  LOCAL_PORT=${LOCAL_PORT:-8000}
+  REMOTE_PORT=${REMOTE_PORT:-9000}
+  echo "[INFO] Reverse tunnel: Codespace localhost:${REMOTE_PORT} → your localhost:${LOCAL_PORT}"
+  ssh -f -N -R "${REMOTE_PORT}:localhost:${LOCAL_PORT}" "$CODESPACE"
+fi
+
+# Wait on sshuttle
+[[ -n "$SSHUTTLE_PID" ]] && wait "$SSHUTTLE_PID"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,5 @@
+name: cs-vpn
+version: 0.0.1
+description: Route traffic through GitHub Codespaces via sshuttle and SSH reverse tunnels
+usage: gh codespaces proxy <codespace-name> [--all] [--dns] [--only-443] [--domains "domain1 domain2"] [--gateway]
+shell: bash


### PR DESCRIPTION
#### Hello world PR.

###  AI Generated Summary

This pull request introduces a new GitHub CLI extension, `cs-vpn`, which allows users to route traffic through GitHub Codespaces using `sshuttle` and optionally set up SSH reverse tunnels. The most important changes include adding detailed documentation, implementing the core functionality in a Bash script, and defining the extension's metadata.

### Documentation and Usage Instructions:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R63): Added comprehensive documentation for the `cs-vpn` extension, including installation steps, usage examples, and explanations of available flags.

### Core Functionality:
* [`cs-vpn`](diffhunk://#diff-f97fdd691949ccdecc366230acac80b0dc08ffe9dfcbcc3d9eddfd980a8044e2R1-R80): Implemented the main Bash script to handle traffic routing and reverse SSH tunneling. The script includes flag parsing, route configuration, and SSH setup.

### Metadata Definition:
* [`manifest.yml`](diffhunk://#diff-24c51d6f58480f0d1e1b3f4068768cbdea5c9896edb96ca0165f8122224217a8R1-R5): Added metadata for the `cs-vpn` extension, including its name, version, description, usage instructions, and shell type.